### PR TITLE
#2 correct logging of exceptions (better logging)

### DIFF
--- a/bin/shell.js
+++ b/bin/shell.js
@@ -12,5 +12,10 @@ ssh
     process.stderr.write(output.error);
   })
   .catch(function onError(err) {
-    process.stderr.write(err);
+    if (err.message) {
+      process.stderr.write(err.message);
+      process.stderr.write(err.stack);
+    } else {
+      process.stderr.write(err);
+    }
   });


### PR DESCRIPTION
example:

bin/shell.js --host 'root@160.48.199.99' --opts '{ "cmd": "ls -la"  }'
Handshake failed: no matching key exchange algorithmError: Handshake failed: no matching key exchange algorithm
    at check_KEXINIT (/.../github/shelljs-plugin-ssh/node_modules/ssh2-streams/lib/ssh.js:2284:15)
    at check (/.../github/shelljs-plugin-ssh/node_modules/ssh2-streams/lib/ssh.js:2222:9)
    at onKEXINIT (/.../github/shelljs-plugin-ssh/node_modules/ssh2-streams/lib/ssh.js:2219:5)
    at SSH2Stream.<anonymous> (/.../github/shelljs-plugin-ssh/node_modules/ssh2-streams/lib/ssh.js:206:5)
    at emitTwo (events.js:106:13)
    at SSH2Stream.emit (events.js:191:7)
    at parse_KEXINIT (/.../github/shelljs-plugin-ssh/node_modules/ssh2-streams/lib/ssh.js:4117:8)
    at parsePacket (/.../github/shelljs-plugin-ssh/node_modules/ssh2-streams/lib/ssh.js:4013:12)
    at SSH2Stream._transform (/.../github/shelljs-plugin-ssh/node_modules/ssh2-streams/lib/ssh.js:669:13)
    at SSH2Stream.Transform._read (_stream_transform.js:167:10)%